### PR TITLE
[ACC-1] Added spring security; Secured getAccount

### DIFF
--- a/src/main/java/mathpar/web/learning/account/_configs/security/SecurityConfiguration.java
+++ b/src/main/java/mathpar/web/learning/account/_configs/security/SecurityConfiguration.java
@@ -1,10 +1,13 @@
-package mathpar.web.learning.account._configs;
+package mathpar.web.learning.account._configs.security;
 
+import mathpar.web.learning.account.services.TokenService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.web.session.ConcurrentSessionFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -13,16 +16,26 @@ import java.util.Collections;
 
 @Configuration
 @EnableWebSecurity
+@EnableGlobalMethodSecurity(prePostEnabled = true, securedEnabled = true)
 public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
+    private final TokenValidationFilter tokenFilter;
+
+    public SecurityConfiguration(TokenService tokenService) {
+        this.tokenFilter = new TokenValidationFilter(tokenService);
+    }
+
     @Override
     protected void configure(HttpSecurity http) throws Exception {
-        http.authorizeRequests().antMatchers("/**").permitAll();
+        http.logout().disable();
+        http.anonymous().disable();
+        http.sessionManagement().disable();
+        http.addFilterAfter(tokenFilter, ConcurrentSessionFilter.class);
         http.csrf().disable();
         http.cors();
     }
 
     @Bean
-    CorsConfigurationSource corsConfigurationSource() {
+    public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowedOrigins(Collections.singletonList("*"));
         configuration.setAllowedMethods(Collections.singletonList("*"));

--- a/src/main/java/mathpar/web/learning/account/_configs/security/TokenValidationFilter.java
+++ b/src/main/java/mathpar/web/learning/account/_configs/security/TokenValidationFilter.java
@@ -1,4 +1,4 @@
-package mathpar.web.learning.account._configs.security;//package mathpar.web.frontend.application._configs.security;
+package mathpar.web.learning.account._configs.security;
 
 import mathpar.web.learning.account.services.TokenService;
 import mathpar.web.learning.account.utils.Constants;

--- a/src/main/java/mathpar/web/learning/account/_configs/security/TokenValidationFilter.java
+++ b/src/main/java/mathpar/web/learning/account/_configs/security/TokenValidationFilter.java
@@ -23,15 +23,15 @@ public class TokenValidationFilter implements Filter {
 
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
-        var token = ((HttpServletRequest) request).getHeader(Constants.TOKEN_HEADER_NAME);
+        var tokenStr = ((HttpServletRequest) request).getHeader(Constants.TOKEN_HEADER_NAME);
         var context = SecurityContextHolder.getContext();
-        if (token == null){
+        if (tokenStr == null){
             context.setAuthentication(new AnonymousAuthenticationToken("anonymous", "anonymous", List.of(new SimpleGrantedAuthority("ROLE_ANONYMOUS"))));
         }
         else {
             try {
-                var tokenStr = tokenService.getToken(token);
-                context.setAuthentication(new UserAuthentication(tokenStr));
+                var token = tokenService.getToken(tokenStr);
+                context.setAuthentication(new UserAuthentication(token));
             } catch (InvalidTokenException e) {
                 sendError(response, 403, "Token is invalid: " + e.getMessage());
                 return;

--- a/src/main/java/mathpar/web/learning/account/_configs/security/TokenValidationFilter.java
+++ b/src/main/java/mathpar/web/learning/account/_configs/security/TokenValidationFilter.java
@@ -1,0 +1,46 @@
+package mathpar.web.learning.account._configs.security;//package mathpar.web.frontend.application._configs.security;
+
+import mathpar.web.learning.account.services.TokenService;
+import mathpar.web.learning.account.utils.Constants;
+import mathpar.web.learning.account.utils.exceptions.InvalidTokenException;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+
+public class TokenValidationFilter implements Filter {
+
+    private final TokenService tokenService;
+
+    public TokenValidationFilter(TokenService tokenService) {
+        this.tokenService = tokenService;
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        var token = ((HttpServletRequest) request).getHeader(Constants.TOKEN_HEADER_NAME);
+        var context = SecurityContextHolder.getContext();
+        if (token == null){
+            context.setAuthentication(new AnonymousAuthenticationToken("anonymous", "anonymous", List.of(new SimpleGrantedAuthority("ROLE_ANONYMOUS"))));
+        }
+        else {
+            try {
+                var tokenStr = tokenService.getToken(token);
+                context.setAuthentication(new UserAuthentication(tokenStr));
+            } catch (InvalidTokenException e) {
+                sendError(response, 403, "Token is invalid: " + e.getMessage());
+                return;
+            }
+        }
+        chain.doFilter(request, response);
+    }
+
+    private void sendError(ServletResponse response, int status, String message) throws IOException {
+        ((HttpServletResponse)response).sendError(status, message);
+    }
+}

--- a/src/main/java/mathpar/web/learning/account/_configs/security/UserAuthentication.java
+++ b/src/main/java/mathpar/web/learning/account/_configs/security/UserAuthentication.java
@@ -1,0 +1,52 @@
+package mathpar.web.learning.account._configs.security;//package mathpar.web.frontend.application._configs.security;
+
+import mathpar.web.learning.account.entities.AuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.Collection;
+import java.util.List;
+
+public class UserAuthentication implements Authentication {
+    private final AuthenticationToken token;
+
+    public UserAuthentication(AuthenticationToken token) {
+        this.token = token;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority("ROLE_ACCOUNT"));
+    }
+
+    @Override
+    public String getCredentials() {
+        return token.getToken();
+    }
+
+    @Override
+    public AuthenticationToken getDetails() {
+        return token;
+    }
+
+    @Override
+    public Long getPrincipal() {
+        return token.getAccountId();
+    }
+
+    @Override
+    public boolean isAuthenticated() {
+        return true;
+    }
+
+    @Override
+    public void setAuthenticated(boolean isAuthenticated) throws IllegalArgumentException {
+    }
+
+    @Override
+    public String getName() {
+        return token.getToken();
+    }
+
+}

--- a/src/main/java/mathpar/web/learning/account/_configs/security/UserAuthentication.java
+++ b/src/main/java/mathpar/web/learning/account/_configs/security/UserAuthentication.java
@@ -1,4 +1,4 @@
-package mathpar.web.learning.account._configs.security;//package mathpar.web.frontend.application._configs.security;
+package mathpar.web.learning.account._configs.security;
 
 import mathpar.web.learning.account.entities.AuthenticationToken;
 import org.springframework.security.core.Authentication;

--- a/src/main/java/mathpar/web/learning/account/controllers/api/AccountController.java
+++ b/src/main/java/mathpar/web/learning/account/controllers/api/AccountController.java
@@ -4,12 +4,13 @@ import io.swagger.annotations.Api;
 import mathpar.web.learning.account.services.AccountService;
 import mathpar.web.learning.account.services.AuthenticationService;
 import mathpar.web.learning.account.utils.PublicApi;
-import mathpar.web.learning.account.utils.TokenUtils;
+import mathpar.web.learning.account.utils.SecurityUtils;
 import mathpar.web.learning.account.utils.dto.AccountPublicInfo;
 import mathpar.web.learning.account.utils.dto.payloads.CreateAccountPayload;
 import mathpar.web.learning.account.utils.dto.responses.AccountResponse;
 import mathpar.web.learning.account.utils.dto.responses.IsEmailAvailableResponse;
 import mathpar.web.learning.account.utils.dto.responses.RegistrationResponse;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -34,10 +35,10 @@ public class AccountController {
         return new IsEmailAvailableResponse(accountService.isEmailAvailable(email));
     }
 
-    //TODO change to spring security usage
     @GetMapping(ACCOUNT_URL)
-    public AccountResponse getAccount(@RequestHeader(value = "AUTH-TOKEN") String token){
-        long id = TokenUtils.mapTokenToId(token);
+    @PreAuthorize("hasRole('ROLE_ACCOUNT')")
+    public AccountResponse getAccount(){
+        long id = SecurityUtils.getCurrentAuthentication().getPrincipal();
         return new AccountResponse(accountService.getAccount(id).orElseThrow());
     }
 

--- a/src/main/java/mathpar/web/learning/account/utils/Constants.java
+++ b/src/main/java/mathpar/web/learning/account/utils/Constants.java
@@ -1,7 +1,5 @@
 package mathpar.web.learning.account.utils;
 
 public class Constants {
-    public static final String USER_ID_HEADER_NAME = "user-id";
-    public static final String INSTITUTION_ID_HEADER_NAME = "institution-id";
-    public static final String INSTITUTION_TYPE_HEADER_NAME = "institution-type";
+    public static final String TOKEN_HEADER_NAME="AUTH-TOKEN";
 }

--- a/src/main/java/mathpar/web/learning/account/utils/SecurityUtils.java
+++ b/src/main/java/mathpar/web/learning/account/utils/SecurityUtils.java
@@ -1,0 +1,10 @@
+package mathpar.web.learning.account.utils;
+
+import mathpar.web.learning.account._configs.security.UserAuthentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class SecurityUtils {
+    public static UserAuthentication getCurrentAuthentication(){
+        return (UserAuthentication) SecurityContextHolder.getContext().getAuthentication();
+    }
+}


### PR DESCRIPTION
## Description
Account service has endpoints which must be protected (accessible only by authenticated/authorized entities). Thus implementation of spring security was required to protect those endpoints. This PR uses the existing authentication mechanism from School service, alters it to fit the account service needs and utilises the new feature to secure the getAccount endpoint.
If no token present in request, the request entity is considered anonymous. Anonymous entity has access to all the endpoints which were not explicitly marked as secured via @Secured or @PreAuthorize

## Testing
This feature was tested locally manually. The test cases were as follows:
Request to /emailAvailable endpoint fails when invalid token is present
Request to /emailAvailable endpoint passes when no token is present
Request to / (getAccount) endpoint fails when no token is present
Request to / (getAccount) endpoint fails when invalid token is present
Request to / (getAccount) endpoint passes when valid token is present